### PR TITLE
Add JOG (hold-to-run) drive — for blinds/awnings whose absolute moves are ACKed but no-op

### DIFF
--- a/warema-bridge/srv/warema-wms-venetian-blinds/stick.js
+++ b/warema-bridge/srv/warema-wms-venetian-blinds/stick.js
@@ -868,6 +868,16 @@ class Stick {
     // with the stick's normal network-key access (NOT an auth/enrollment issue: reads and jog both
     // work from the same stick). direction 'up'|'down' -> WMS sub-cmds 07/06; the physical sense
     // depends on the motor's install side. See https://github.com/vyakunin/warema-wms-jog
+    //
+    // The jog frame is written DIRECTLY to the stick on the dead-man interval, NOT routed through the
+    // FIFO cmd queue. The queue only advances a message on an expected response or a full `timeout`
+    // dwell (see how scanRequest/ack — the other no-response frames — are handled), so streaming jog
+    // through it would (a) throttle the real send rate to `timeout` (200ms) instead of intervalMsec,
+    // spamming a wmsTimeout per frame, and (b) let the queue grow without bound whenever the interval
+    // outpaces the dwell — leaving a backlog of jog frames that keep driving the motor AFTER
+    // vnBlindJogStop (dangerous for a no-hard-stop awning). A direct write is atomic per frame,
+    // matches the intended cadence exactly, queues nothing, and stops the instant the interval is
+    // cleared. The stop command still goes through the FIFO (it wants an ack).
     // SAFETY: jog enforces no soft limit here. An awning's extend/out direction may have NO hard
     // stop (fabric runs out) - the CALLER must bound run time and/or poll position and stop in time.
     vnBlindJogStart(id, direction = 'up', intervalMsec = 140) {
@@ -882,11 +892,11 @@ class Stick {
             clearInterval(stickObj.jogTimers[blind.snr]);
         }
         var dir = (direction === 'down') ? 'down' : 'up';
+        // Encode the jog frame once — snr + direction are fixed for this run.
+        var jogCmd = new wmsUtil.wmsMsgNew("blindJog", blind.snr, {dir: dir}).stickCmd.cmd;
         function sendOneJogFrame() {
-            privateCmdQueueEnqueue(stickObj, new wmsUtil.wmsMsgNew("blindJog", blind.snr, {dir: dir}), privateHandleWmsCompletionGeneric);
-            setTimeout(function () {
-                privateCmdQueueProcess(stickObj);
-            }, DELAY_MSG_PROC);
+            log.silly("vnBlindJog stream " + blind.snr + " " + JSON.stringify(jogCmd) + ".");
+            stickObj.comDataSendCallback(jogCmd);
         }
         sendOneJogFrame();
         stickObj.jogTimers[blind.snr] = setInterval(sendOneJogFrame, intervalMsec);

--- a/warema-bridge/srv/warema-wms-venetian-blinds/stick.js
+++ b/warema-bridge/srv/warema-wms-venetian-blinds/stick.js
@@ -467,6 +467,7 @@ class Stick {
             this.comDataSendCallback = comDataSendCallback; // function ( string );
         }
         this.vnBlinds = [];
+        this.jogTimers = {}; // snr -> setInterval handle for an active dead-man jog (see vnBlindJogStart)
         this.wmsMsgQueue = [];
         this.currentWmsMsg = undefined;
         this.currentTimeout = undefined;
@@ -858,6 +859,54 @@ class Stick {
     // ~ ~ method ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~
     setCmdConfirmationNotificationEnabled(enabled) {
         this.enableCmdConfirmationNotification = !!enabled
+    }
+
+    // ~ ~ method ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~
+    // JOG (hold-to-run) drive. Streams the jog frame every intervalMsec until vnBlindJogStop is
+    // called. Unlike vnBlindSetPosition (absolute blindMoveToPos), jog is NOT gated by transmitter
+    // enrollment, so it drives an actuator even when this stick only holds the network key (read
+    // access) and absolute moves are refused. direction 'up'|'down' -> WMS sub-cmds 07/06; the
+    // physical sense depends on the motor's install side. See https://github.com/vyakunin/warema-wms-jog
+    // SAFETY: jog enforces no soft limit here. An awning's extend/out direction may have NO hard
+    // stop (fabric runs out) - the CALLER must bound run time and/or poll position and stop in time.
+    vnBlindJogStart(id, direction = 'up', intervalMsec = 140) {
+        log.info("vnBlindJogStart( (" + (typeof id) + ") \"" + id + "\", " + direction + " )");
+        var stickObj = this;
+        var blind = stickObj.vnBlindGet(id);
+        if (!blind) {
+            log.W("vnBlindJogStart: Cannot find blind \"" + id + "\".");
+            return;
+        }
+        if (stickObj.jogTimers[blind.snr]) {
+            clearInterval(stickObj.jogTimers[blind.snr]);
+        }
+        var dir = (direction === 'down') ? 'down' : 'up';
+        function sendOneJogFrame() {
+            privateCmdQueueEnqueue(stickObj, new wmsUtil.wmsMsgNew("blindJog", blind.snr, {dir: dir}), privateHandleWmsCompletionGeneric);
+            setTimeout(function () {
+                privateCmdQueueProcess(stickObj);
+            }, DELAY_MSG_PROC);
+        }
+        sendOneJogFrame();
+        stickObj.jogTimers[blind.snr] = setInterval(sendOneJogFrame, intervalMsec);
+    }
+
+    // ~ ~ method ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~
+    // Stop an active jog: clears the dead-man stream timer and sends blindStopMove (which also reads
+    // back position when getPosOnStop is true).
+    vnBlindJogStop(id, getPosOnStop = true) {
+        log.info("vnBlindJogStop( (" + (typeof id) + ") \"" + id + "\" )");
+        var stickObj = this;
+        var blind = stickObj.vnBlindGet(id);
+        if (!blind) {
+            log.W("vnBlindJogStop: Cannot find blind \"" + id + "\".");
+            return;
+        }
+        if (stickObj.jogTimers[blind.snr]) {
+            clearInterval(stickObj.jogTimers[blind.snr]);
+            delete stickObj.jogTimers[blind.snr];
+        }
+        stickObj.vnBlindStop(blind.snr, getPosOnStop);
     }
 
     // ~ ~ method ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~

--- a/warema-bridge/srv/warema-wms-venetian-blinds/stick.js
+++ b/warema-bridge/srv/warema-wms-venetian-blinds/stick.js
@@ -863,10 +863,11 @@ class Stick {
 
     // ~ ~ method ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~
     // JOG (hold-to-run) drive. Streams the jog frame every intervalMsec until vnBlindJogStop is
-    // called. Unlike vnBlindSetPosition (absolute blindMoveToPos), jog is NOT gated by transmitter
-    // enrollment, so it drives an actuator even when this stick only holds the network key (read
-    // access) and absolute moves are refused. direction 'up'|'down' -> WMS sub-cmds 07/06; the
-    // physical sense depends on the motor's install side. See https://github.com/vyakunin/warema-wms-jog
+    // called. Use it for actuators that ACK absolute vnBlindSetPosition (blindMoveToPos) but never
+    // move — notably awnings, which generally have no intermediate positioning. Jog drives them
+    // with the stick's normal network-key access (NOT an auth/enrollment issue: reads and jog both
+    // work from the same stick). direction 'up'|'down' -> WMS sub-cmds 07/06; the physical sense
+    // depends on the motor's install side. See https://github.com/vyakunin/warema-wms-jog
     // SAFETY: jog enforces no soft limit here. An awning's extend/out direction may have NO hard
     // stop (fabric runs out) - the CALLER must bound run time and/or poll position and stop in time.
     vnBlindJogStart(id, direction = 'up', intervalMsec = 140) {

--- a/warema-bridge/srv/warema-wms-venetian-blinds/wms-util.js
+++ b/warema-bridge/srv/warema-wms-venetian-blinds/wms-util.js
@@ -96,6 +96,11 @@ function wmsMsgNew(cmd, snr, params) {
                 this.delayAfter = 5;
                 this.retry = 3;
                 break;
+            case "blindJog"      :
+                this.timeout = 200;
+                this.delayAfter = 5;
+                this.retry = -1; // dead-man stream: never wait/retry, the caller re-sends ~7x/s
+                break;
             case "waveRequest"   :
                 this.timeout = 500;
                 this.delayAfter = 300;
@@ -142,6 +147,19 @@ function encodeCmd(cmd, snr, params) {
             ret.cmd = '{R06' + snrHex + "7070" + "01" + "FF" + "FF" + "FFFF00}";
             ret.expect.msgType = "blindMoveToPosResponse";
             ret.expect.snr = snrHex;
+            break;
+        case "blindJog":
+            // Dead-man / hold-to-run drive. Unlike blindMoveToPos (absolute, sub-cmd 03), JOG is NOT
+            // gated by transmitter enrollment: a stick that joined the network (has the key -> can
+            // read positions) but is not enrolled as an authorized transmitter still drives the
+            // actuator by STREAMING this frame ~7x/s and then sending blindStopMove. Sub-cmds 06/07
+            // are the two drive directions; physical up/down depends on the motor's install side
+            // (same caveat as drehrichtung). No response is expected (continuous stream) so the cmd
+            // sets retry = -1 and an empty expect. Verified 2026-06 on a WMS-MM awning whose absolute
+            // moves were protocol-ACKed but dropped. See https://github.com/vyakunin/warema-wms-jog
+            ret.cmd = '{R06' + snrHex + '7070' + (params.dir === 'down' ? '06' : '07') + 'FFFFFFFF}';
+            ret.expect.msgType = "";
+            ret.expect.snr = undefined;
             break;
         case "stickGetName":
             ret.cmd = '{G}';

--- a/warema-bridge/srv/warema-wms-venetian-blinds/wms-util.js
+++ b/warema-bridge/srv/warema-wms-venetian-blinds/wms-util.js
@@ -149,14 +149,16 @@ function encodeCmd(cmd, snr, params) {
             ret.expect.snr = snrHex;
             break;
         case "blindJog":
-            // Dead-man / hold-to-run drive. Unlike blindMoveToPos (absolute, sub-cmd 03), JOG is NOT
-            // gated by transmitter enrollment: a stick that joined the network (has the key -> can
-            // read positions) but is not enrolled as an authorized transmitter still drives the
-            // actuator by STREAMING this frame ~7x/s and then sending blindStopMove. Sub-cmds 06/07
-            // are the two drive directions; physical up/down depends on the motor's install side
-            // (same caveat as drehrichtung). No response is expected (continuous stream) so the cmd
-            // sets retry = -1 and an empty expect. Verified 2026-06 on a WMS-MM awning whose absolute
-            // moves were protocol-ACKed but dropped. See https://github.com/vyakunin/warema-wms-jog
+            // Dead-man / hold-to-run drive, for actuators that ACK absolute blindMoveToPos (sub-cmd
+            // 03) but never execute it — notably awnings, which generally have no intermediate
+            // positioning. JOG drives the motor with the stick's normal network-key access; this is
+            // NOT an auth/enrollment issue (reads and jog both work from the same stick — same
+            // sender/actuator/auth context, only the subcommand differs). Stream this frame ~7x/s
+            // then send blindStopMove. Sub-cmds 06/07 are the two drive directions; physical up/down
+            // depends on the motor's install side (same caveat as drehrichtung). No response is
+            // expected (continuous stream) so the cmd sets retry = -1 and an empty expect. Verified
+            // 2026-06 on a WMS-MM awning whose absolute moves were ACKed but no-op. See
+            // https://github.com/vyakunin/warema-wms-jog
             ret.cmd = '{R06' + snrHex + '7070' + (params.dir === 'down' ? '06' : '07') + 'FFFFFFFF}';
             ret.expect.msgType = "";
             ret.expect.snr = undefined;

--- a/warema-bridge/srv/warema-wms-venetian-blinds/wms-util.js
+++ b/warema-bridge/srv/warema-wms-venetian-blinds/wms-util.js
@@ -97,9 +97,12 @@ function wmsMsgNew(cmd, snr, params) {
                 this.retry = 3;
                 break;
             case "blindJog"      :
+                // Jog is written directly to the stick on a dead-man interval, NOT routed through the
+                // cmd queue (see vnBlindJogStart), so these queue fields are unused — only stickCmd.cmd
+                // is consumed. Left as sane defaults for parity with the other command definitions.
                 this.timeout = 200;
                 this.delayAfter = 5;
-                this.retry = -1; // dead-man stream: never wait/retry, the caller re-sends ~7x/s
+                this.retry = -1;
                 break;
             case "waveRequest"   :
                 this.timeout = 500;


### PR DESCRIPTION
## Add JOG (hold-to-run) drive — for blinds/awnings whose absolute moves are ACKed but no-op

A recurring problem with the WMS stick: the add-on discovers the device and shows its position,
but **open/close does nothing** — the log shows `wmsRetry blindMoveToPos` → `wmsTimeout`, or the
actuator ACKs (`7071…`) without moving. It's often blamed on USB3 interference or range, and
sometimes that's right — but on some installs reads work perfectly and only the move no-ops.

This shows up especially on **awnings**, which generally have no intermediate positioning the way
venetian blinds do — so an absolute `blindMoveToPos` (`7070 03`) is acknowledged but the motor
never executes it.

**It is not an authorization/enrollment problem.** (An earlier version of this PR text said it
was — that was wrong.) Jog (`7070 06/07`, below) and absolute (`7070 03`) are sent from the **same
stick → same actuator → same network-key auth context**; only the subcommand differs. Jog drives
the motor, so the stick is clearly authorized to transmit — the network-key access handles auth,
and `blindMoveToPos` works fine for venetian blinds over the same stick. What's left is a
command/device-capability gap on these actuators, and **jog drives them**:

Verified 2026-06 on a WMS-MM awning whose absolute moves were ACKed but no-op — jog drove it
cleanly in both directions (position read-back + visual).

### What this PR adds (additive, non-breaking)

- **`wms-util.js`** — `blindJog` command: `{R06<snr>7070 06|07 FFFFFFFF}` (`06`/`07` = the two
  directions; physical up/down depends on install side, same caveat as `drehrichtung`). No
  response expected, `retry = -1` (continuous stream).
- **`stick.js`**
  - `vnBlindJogStart(id, direction='up', intervalMsec=140)` — streams the jog frame dead-man,
    keyed by SNR in `this.jogTimers`.
  - `vnBlindJogStop(id, getPosOnStop=true)` — clears the timer, sends `blindStopMove`.

It deliberately does **not** rewire the MQTT bridge to jog-by-default: jog needs caller-side
run-time/position bounding (an awning's extend direction may have **no hard stop**). The primitive
is exposed so a bridge or downstream can build bounded open/close/set-position on it.

### Verification

- **Telegram bytes verified on hardware** — exactly the frames proven to drive a real WMS-MM actuator.
- **Syntax verified** — `node -c` on both files (Node 20).
- Not yet smoke-tested through this JS library end-to-end on hardware (my production driver is a
  separate Python implementation sending the identical telegrams) — worth a hardware smoke-test
  before merge.

### Background, byte-level evidence, safety notes, and a complete standalone HA cover

Full writeup + a battle-tested standalone Python HA MQTT cover that drives via bounded jog
(position slider, extend-cap, remote-move tracking) + this patch:
**https://github.com/vyakunin/warema-wms-jog**

⚠️ **Safety:** jog has no soft-limit enforcement; an awning's extend/out direction may have no hard
stop (fabric runs out). Any consumer must bound run time and/or poll position and stop in time.
